### PR TITLE
Update dependencies (Gemnasium auto-update d64dc6a3554c73a5630ee93edd83f2c13d8600e8)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,11 +60,11 @@ GEM
       coderay (>= 1.0.0)
       erubis (>= 2.6.6)
       rack (>= 0.9.0)
-    bootstrap-generators (3.1.1.3)
+    bootstrap-generators (3.3.4)
       railties (>= 3.1.0)
-    bootstrap-sass (3.3.5)
+    bootstrap-sass (3.3.5.1)
       autoprefixer-rails (>= 5.0.0.1)
-      sass (>= 3.2.19)
+      sass (>= 3.3.0)
     builder (3.2.2)
     byebug (5.0.0)
       columnize (= 0.9.0)
@@ -92,7 +92,7 @@ GEM
       timers (>= 4.1.1)
     chronic (0.10.2)
     coderay (1.1.0)
-    coffee-rails (4.0.1)
+    coffee-rails (4.1.0)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.0)
     coffee-script (2.4.1)
@@ -132,7 +132,6 @@ GEM
       activesupport (>= 4.1.0)
     haml (4.0.7)
       tilt
-    hike (1.2.3)
     hirb (0.7.3)
     hitimes (1.2.3)
     http-cookie (1.0.2)
@@ -290,12 +289,13 @@ GEM
       ruby-progressbar (~> 1.4)
     ruby-progressbar (1.7.5)
     safe_yaml (1.0.4)
-    sass (3.2.19)
-    sass-rails (4.0.5)
+    sass (3.4.18)
+    sass-rails (5.0.4)
       railties (>= 4.0.0, < 5.0)
-      sass (~> 3.2.2)
-      sprockets (~> 2.8, < 3.0)
-      sprockets-rails (~> 2.0)
+      sass (~> 3.1)
+      sprockets (>= 2.8, < 4.0)
+      sprockets-rails (>= 2.0, < 4.0)
+      tilt (>= 1.1, < 3)
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
@@ -324,18 +324,15 @@ GEM
     spring (1.4.0)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
-    sprockets (2.12.4)
-      hike (~> 1.2)
-      multi_json (~> 1.0)
-      rack (~> 1.0)
-      tilt (~> 1.1, != 1.3.0)
+    sprockets (3.4.0)
+      rack (> 1, < 3)
     sprockets-rails (2.3.3)
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
     thor (0.19.1)
     thread_safe (0.3.5)
-    tilt (1.4.1)
+    tilt (2.0.1)
     timecop (0.8.0)
     timers (4.1.1)
       hitimes
@@ -363,10 +360,10 @@ DEPENDENCIES
   activerecord-import
   batoto_ripper!
   better_errors
-  bootstrap-generators (~> 3.1.1)
+  bootstrap-generators (~> 3.3)
   bootstrap-sass
   carrierwave
-  coffee-rails (~> 4.0.0)
+  coffee-rails (~> 4.1.0)
   colored
   devise
   dotenv-rails
@@ -374,7 +371,7 @@ DEPENDENCIES
   jazz_fingers
   jbuilder (~> 2.0)
   jquery-rails
-  kaminari-bootstrap (~> 3.0.1)
+  kaminari-bootstrap (~> 3.0)
   paper_trail
   pg
   psych (~> 2.0.0)
@@ -384,7 +381,7 @@ DEPENDENCIES
   rspec (~> 3.3.0.beta2)
   rspec-rails (~> 3.3.0)
   rubocop
-  sass-rails (~> 4.0.3)
+  sass-rails (~> 5.0.0)
   sdoc (~> 0.4.0)
   seven_zip_ruby
   sidekiq


### PR DESCRIPTION
Update dependencies:
sass-rails: 4.0.5 => 5.0.4
tilt: 1.4.1 => 2.0.1
bootstrap-sass: 3.3.5 => 3.3.5.1
coffee-rails: 4.0.1 => 4.1.0
sass: 3.2.19 => 3.4.18
sprockets: 2.12.4 => 3.4.0
bootstrap-generators: 3.1.1.3 => 3.3.4
kaminari-bootstrap: 3.0.1 => 3.0.1
